### PR TITLE
APIの返り値のテキストの重複除去処理を追加

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -49,7 +49,7 @@ export default function Search() {
         const uniqueTexts = Array.from(new Set(texts).values());
         setQueryErrorContents(uniqueTexts);
         return router.push(
-          `https://google.com/search?q=${uniqueTexts}&lr=lang_ja`,
+          `https://google.com/search?q=${uniqueTexts.join('+')}&lr=lang_ja`,
         );
       });
   };

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -42,7 +42,9 @@ export default function Search() {
       .then((res) => res.json())
       .then((data) => {
         console.log(data);
-        setQueryErrorContents(data.result.map((x: { text: any }) => x.text) as []);
+        const texts = data.result.map((x: { text: string }) => x.text) as [];
+        const uniqueTexts = Array.from(new Set(texts).values());
+        setQueryErrorContents(uniqueTexts);
       });
   };
 


### PR DESCRIPTION
## やったこと

* APIの返り値のテキストの重複除去処理を追加

## できるようになること（ユーザ目線）

* クエリ生成の際に同じライブラリ名が表示されないようになった

## できなくなること（ユーザ目線）

* 無し

## その他

* 無し

close #61 
