### PR TITLE
URLとFILE PATHの除去処理を再度追加

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -34,7 +34,7 @@ not_found_pattern = re.compile(r".*N(ot|OT)[ |_]?F(ound|OUND).+")
 url_pattern = re.compile(
     r"http(s)?:\/\/[\w./%-]+(\:\d{1,})?(\?)?(((\w+)=?[\w,%0-9]+)&?)*"
 )
-unix_path_pattern = re.compile(r"[\"\']?(\/)?\w+\/[^\"\'\) ]+[\"\']?")
+unix_path_pattern = re.compile(r"[\"\']?(\.)?(\/)?\w+\/[^\"\'\) ]+[\"\']?")
 
 
 class TextType(Enum):

--- a/server/main.py
+++ b/server/main.py
@@ -170,7 +170,7 @@ def python_error(error: str) -> list[HighlightTextInfo]:
     row_idx, last_line = len(lines), lines[-1]
     # URL は検索クエリに使えないので除去するが，FILE情報の位置はそのまま保持しておく
     error_text = url_pattern.sub('', last_line)
-    error_text = unix_path_pattern.sub('__FILE__', error_text)
+    error_text = unix_path_pattern.sub('', error_text)
 
     stdlibs, extlibs = get_python_libs(lines)
     last_message = HighlightTextInfo(row_idx, TextIndices(0, len(last_line)), error_text, TextType.ERROR_MESSAGE)

--- a/server/main.py
+++ b/server/main.py
@@ -167,17 +167,13 @@ def python_error(error: str) -> list[HighlightTextInfo]:
     """
     """
     lines = error.rstrip('\n').splitlines()
-    result = []
     row_idx, last_line = len(lines), lines[-1]
-    error_type, *description = last_line.split(":")
-    if error_type == "ImportError":
-        error_text = unix_path_pattern.sub('__FILE__', last_line)
-        result.append(
-            HighlightTextInfo(row_idx, TextIndices(0, len(last_line)), error_text, TextType.ERROR_MESSAGE)
-        )
+    # URL は検索クエリに使えないので除去するが，FILE情報の位置はそのまま保持しておく
+    error_text = url_pattern.sub('', last_line)
+    error_text = unix_path_pattern.sub('__FILE__', error_text)
 
-    stdlibs, extlibs = get_python_libs(error.splitlines())
-    last_message = HighlightTextInfo(row_idx, TextIndices(0, len(last_line)), last_line, TextType.ERROR_MESSAGE)
+    stdlibs, extlibs = get_python_libs(lines)
+    last_message = HighlightTextInfo(row_idx, TextIndices(0, len(last_line)), error_text, TextType.ERROR_MESSAGE)
     return [*stdlibs, *extlibs, last_message]
 
 


### PR DESCRIPTION
## やったこと

* URLと FILE PATHの除去処理を追加した

## できるようになること（ユーザ目線）

* `*Error` 系のログにURLやファイルパスがある場合に除去されるので検索しやすくなる

## できなくなること（ユーザ目線）

* 無し

## その他

下のエラーメッセージを入力すると，最後の行の `/usr/loca/lib/.../__init__.py` が除去される．

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.10/site-packages/uvicorn/server.py", line 67, in serve
    config.load()
  File "/usr/local/lib/python3.10/site-packages/uvicorn/config.py", line 479, in load
    self.loaded_app = import_from_string(self.app)
  File "/usr/local/lib/python3.10/site-packages/uvicorn/importer.py", line 24, in import_from_string
    raise exc from None
  File "/usr/local/lib/python3.10/site-packages/uvicorn/importer.py", line 21, in import_from_string
    module = importlib.import_module(module_str)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/usr/src/app/web/./main.py", line 2, in <module>
    from fastapi import (
ImportError: cannot import name 'BaseModel' from 'fastapi' (/usr/local/lib/python3.10/site-packages/fastapi/__init__.py)
```

close #66 
