### PR TITLE
#77 UIのリニューアル

### DIFF
--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -10,7 +10,6 @@ import {
   MenuItem,
   IconButton,
   InputAdornment,
-  InputLabel,
   OutlinedInput,
   Select,
   Stack,

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,25 +1,27 @@
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import {
   Alert,
+  Box,
+  Button,
+  Container,
   Fade,
+  FormControl,
+  FormHelperText,
+  MenuItem,
   IconButton,
   InputAdornment,
+  InputLabel,
   OutlinedInput,
+  Select,
   Stack,
+  Typography,
+  SelectChangeEvent,
 } from '@mui/material';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Container from '@mui/material/Container';
-import FormControl from '@mui/material/FormControl';
-import InputLabel from '@mui/material/InputLabel';
-import MenuItem from '@mui/material/MenuItem';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
-import TextField from '@mui/material/TextField';
-import Typography from '@mui/material/Typography';
 import Head from 'next/head';
-import { Router as redu, useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import * as React from 'react';
 import CodeArea from '../src/components/codeArea';
+import Header from '../src/components/header';
 
 export default function Search() {
   const [os, setOS] = React.useState('');
@@ -115,119 +117,197 @@ export default function Search() {
   };
 
   return (
-    <Container maxWidth='lg'>
+    <Box>
       <Head>
         <title>YouQuery</title>
       </Head>
-      <Box
-        sx={{
-          my: 4,
-          pb: 4,
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-          borderBottom: 1,
-          borderColor: 'grey.500',
-        }}
-      >
-        <Typography variant='h1' component='h1' gutterBottom>
-          YouQuery
-        </Typography>
-        <FormControl fullWidth sx={{ m: 1 }}>
-          <InputLabel id='demo-simple-select-label'>OS</InputLabel>
-          <Select
-            labelId='demo-simple-select-label'
-            id='demo-simple-select'
-            value={os}
-            label='OS'
-            onChange={handleChangeOS}
+
+      <Header />
+
+      <Box sx={{ py: 4, bgcolor: 'grey.100' }}>
+        <Container maxWidth='lg'>
+          <Stack
+            direction='column'
+            justifyContent='center'
+            alignItems='center'
+            spacing={2}
           >
-            <MenuItem value={'macOS'}>macOS</MenuItem>
-            {/* <MenuItem value={'Windows'}>Windows</MenuItem> */}
-          </Select>
-        </FormControl>
-        <FormControl fullWidth sx={{ m: 1 }}>
-          <InputLabel id='demo-simple-select-label'>言語</InputLabel>
-          <Select
-            labelId='demo-simple-select-label'
-            id='demo-simple-select'
-            value={language}
-            label='言語'
-            onChange={handleChangeLanguage}
+            <FormControl fullWidth>
+              <FormHelperText
+                component='div'
+                sx={{
+                  m: 0,
+                  fontSize: '1rem',
+                }}
+              >
+                エラー文
+              </FormHelperText>
+              <OutlinedInput
+                placeholder='解決したいエラー文を入力してくだい。'
+                id='errorText'
+                value={error}
+                onChange={handleChangeError}
+                multiline
+                rows={10}
+                sx={{
+                  bgcolor: 'white',
+                }}
+              />
+            </FormControl>
+            <FormControl fullWidth>
+              <FormHelperText
+                component='div'
+                sx={{
+                  m: 0,
+                  fontSize: '1rem',
+                }}
+              >
+                言語
+              </FormHelperText>
+              <Select
+                id='language'
+                value={language}
+                onChange={handleChangeLanguage}
+                displayEmpty
+                sx={{
+                  bgcolor: 'white',
+                }}
+              >
+                <MenuItem value={''}>指定なし</MenuItem>
+                <MenuItem value={'Python'}>Python</MenuItem>
+                <MenuItem value={'Others'}>Others</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl fullWidth>
+              <FormHelperText
+                component='div'
+                sx={{
+                  m: 0,
+                  fontSize: '1rem',
+                }}
+              >
+                OS
+              </FormHelperText>
+              <Select
+                id='os'
+                value={os}
+                onChange={handleChangeOS}
+                displayEmpty
+                sx={{
+                  bgcolor: 'white',
+                }}
+              >
+                <MenuItem value={''}>指定なし</MenuItem>
+                <MenuItem value={'macOS'}>macOS</MenuItem>
+                {/* <MenuItem value={'Windows'}>Windows</MenuItem> */}
+              </Select>
+            </FormControl>
+          </Stack>
+          <Stack
+            direction='row'
+            justifyContent='center'
+            alignItems='center'
+            sx={{ py: 4 }}
           >
-            <MenuItem value={'Python'}>Python</MenuItem>
-            <MenuItem value={'Others'}>Others</MenuItem>
-          </Select>
-        </FormControl>
-        <TextField
-          id='outlined-multiline-static'
-          label='エラー文'
-          sx={{ m: 1 }}
-          fullWidth
-          multiline
-          rows={10}
-          value={error}
-          onChange={handleChangeError}
-        />
-        <Stack direction='row' spacing={8} sx={{ m: 4 }}>
-          <Button
-            variant='contained'
-            sx={{ width: 200, height: 50 }}
-            onClick={handleClickAnalyze}
-          >
-            解析・生成
-          </Button>
-          <Button
-            variant='contained'
-            sx={{ width: 200, height: 50 }}
-            onClick={handleClickSearch}
-          >
-            検索
-          </Button>
-        </Stack>
+            <Button
+              variant='contained'
+              sx={{
+                width: 200,
+                height: 50,
+              }}
+              onClick={handleClickAnalyze}
+            >
+              解析
+            </Button>
+          </Stack>
+        </Container>
       </Box>
-      <Box sx={{ mb: 10 }}>
-        <Typography
-          id='result-content'
-          variant='h6'
-          component='h2'
-          gutterBottom
-        >
-          解析・生成結果
-        </Typography>
-        <Stack spacing={2} sx={{ mt: 2, mb: 8 }}>
-          <FormControl>
-            <InputLabel>検索文字列</InputLabel>
-            <OutlinedInput
-              inputProps={{ readOnly: true }}
-              value={searchQuery}
-              label='検索文字列'
-              endAdornment={
-                <InputAdornment position='end'>
-                  <Box sx={{ zIndex: 'modal', pr: 1 }}>
-                    <Fade in={openSnackbar}>
-                      <Alert icon={false} severity='success'>
-                        Copied
-                      </Alert>
-                    </Fade>
-                  </Box>
-                  <IconButton
-                    aria-label='Click to copy'
-                    onClick={handleClickCopy}
-                    onMouseDown={handleMouseDownCopy}
-                    onMouseOut={handleCloseCopyAlert}
-                    edge='end'
-                  >
-                    <ContentCopyIcon />
-                  </IconButton>
-                </InputAdornment>
-              }
-            />
-          </FormControl>
-          <CodeArea errorText={analizedError} highlights={highlights} />
-        </Stack>
+
+      <Box sx={{ pt: 4, pb: 8, bgcolor: 'white' }}>
+        <Container maxWidth='lg'>
+          <Stack
+            direction='column'
+            justifyContent='center'
+            alignItems='center'
+            spacing={2}
+          >
+            <Typography
+              id='result-content'
+              variant='h6'
+              component='h2'
+              gutterBottom
+            >
+              解析結果
+            </Typography>
+            <CodeArea errorText={analizedError} highlights={highlights} />
+          </Stack>
+        </Container>
       </Box>
-    </Container>
+
+      <Box sx={{ py: 4, bgcolor: 'grey.100' }}>
+        <Container maxWidth='lg'>
+          <Stack
+            direction='column'
+            justifyContent='center'
+            alignItems='center'
+            spacing={2}
+          >
+            <Typography
+              id='result-content'
+              variant='h6'
+              component='h2'
+              gutterBottom
+            >
+              検索クエリ案
+            </Typography>
+            <FormControl fullWidth>
+              <InputLabel>検索文字列</InputLabel>
+              <OutlinedInput
+                inputProps={{ readOnly: true }}
+                value={searchQuery}
+                label='検索文字列'
+                sx={{
+                  bgcolor: 'white',
+                }}
+                endAdornment={
+                  <InputAdornment position='end'>
+                    <Box sx={{ zIndex: 'modal', pr: 1 }}>
+                      <Fade in={openSnackbar}>
+                        <Alert icon={false} severity='success'>
+                          Copied
+                        </Alert>
+                      </Fade>
+                    </Box>
+                    <IconButton
+                      aria-label='Click to copy'
+                      onClick={handleClickCopy}
+                      onMouseDown={handleMouseDownCopy}
+                      onMouseOut={handleCloseCopyAlert}
+                      edge='end'
+                    >
+                      <ContentCopyIcon />
+                    </IconButton>
+                  </InputAdornment>
+                }
+              />
+            </FormControl>
+          </Stack>
+          <Stack
+            direction='row'
+            justifyContent='center'
+            alignItems='center'
+            sx={{ py: 4 }}
+          >
+            <Button
+              variant='contained'
+              sx={{ width: 200, height: 50 }}
+              onClick={handleClickSearch}
+            >
+              検索
+            </Button>
+          </Stack>
+        </Container>
+      </Box>
+    </Box>
   );
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -53,7 +53,6 @@ export default function Search() {
 
   const handleClickAnalyze = () => {
     if (error.length > 0) {
-      console.log(`${os}, ${language}, ${error}`);
       fetch(`${BACKEND_ENDPOINT}/error_parse`, {
         method: 'POST',
         headers: {
@@ -82,7 +81,6 @@ export default function Search() {
   const router = useRouter();
 
   const handleClickSearch = () => {
-    console.log(`${os}, ${language}, ${error}`);
     fetch(`${BACKEND_ENDPOINT}/error_parse`, {
       method: 'POST',
       headers: {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -262,14 +262,21 @@ export default function Search() {
                   component='h2'
                   gutterBottom
                 >
-                  検索クエリ案
+                  検索クエリ候補
                 </Typography>
                 <FormControl fullWidth>
-                  <InputLabel>検索文字列</InputLabel>
+                  <FormHelperText
+                    component='div'
+                    sx={{
+                      m: 0,
+                      fontSize: '1rem',
+                    }}
+                  >
+                    検索文字列
+                  </FormHelperText>
                   <OutlinedInput
                     inputProps={{ readOnly: true }}
                     value={searchQuery}
-                    label='検索文字列'
                     sx={{
                       bgcolor: 'white',
                     }}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -90,9 +90,7 @@ export default function Search() {
           x.type == 1 ? x.text : '',
         ) as [];
         const uniqueTexts = Array.from(new Set(texts).values());
-        return router.push(
-          `https://google.com/search?q=${uniqueTexts.join('+')}&lr=lang_ja`,
-        );
+        open(`https://google.com/search?q=${uniqueTexts.join('+')}&lr=lang_ja`);
       })
       .catch((error) => {
         console.error('通信に失敗しました', error);

--- a/web/src/components/codeArea.tsx
+++ b/web/src/components/codeArea.tsx
@@ -1,4 +1,4 @@
-import Box from '@mui/material/Box';
+import { Box } from '@mui/material';
 import * as React from 'react';
 
 export interface CodeAreaProps {
@@ -35,71 +35,75 @@ export default function CodeArea({ errorText, highlights }: CodeAreaProps) {
     }
   };
 
-  return (
-    <Box>
-      {errorText.length > 0 && (
-        <div
+  const tabelRow = function (i: number, v: JSX.Element[] | string) {
+    return (
+      <tr
+        key={i}
+        style={{
+          padding: 0,
+        }}
+      >
+        <td
           style={{
-            width: '100%',
+            width: 52,
             padding: 0,
-            paddingTop: 4,
-            paddingBottom: 4,
-            borderStyle: 'solid',
-            borderWidth: 1,
-            borderColor: 'rgba(0, 0, 0, 0.23)',
-            borderRadius: 4,
+            paddingLeft: 8,
+            paddingRight: 8,
+            textAlign: 'right',
+            verticalAlign: 'top',
+            userSelect: 'none',
+            color: 'dimgray',
+            backgroundColor: '#f5f5f5',
           }}
         >
-          <table
-            style={{
-              width: '100%',
-              borderSpacing: 0,
-              borderCollapse: 'collapse',
-              fontFamily: 'monospace',
-              fontSize: `0.9rem`,
-              tableLayout: 'fixed',
-            }}
-          >
-            <tbody>
-              {errorText.split('\n').map((v, i) => (
-                <tr
-                  key={i + 1}
-                  style={{
-                    padding: 0,
-                  }}
-                >
-                  <td
-                    style={{
-                      width: 40,
-                      padding: 0,
-                      paddingLeft: 8,
-                      paddingRight: 8,
-                      textAlign: 'right',
-                      verticalAlign: 'top',
-                      userSelect: 'none',
-                      color: 'dimgray',
-                    }}
-                  >
-                    {i + 1}
-                  </td>
-                  <td
-                    style={{
-                      padding: 0,
-                      paddingLeft: 8,
-                      paddingRight: 8,
-                      textAlign: 'left',
-                      verticalAlign: 'top',
-                      whiteSpace: 'pre-wrap',
-                    }}
-                  >
-                    {highlight(v, i)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
+          {i}
+        </td>
+        <td
+          style={{
+            padding: 0,
+            paddingLeft: 8,
+            paddingRight: 8,
+            textAlign: 'left',
+            verticalAlign: 'top',
+            whiteSpace: 'pre-wrap',
+          }}
+        >
+          {v}
+        </td>
+      </tr>
+    );
+  };
+
+  return (
+    <Box>
+      <div
+        style={{
+          width: '100%',
+          padding: '4px',
+          borderStyle: 'solid',
+          borderWidth: 1,
+          borderColor: 'rgba(0, 0, 0, 0.23)',
+          borderRadius: 4,
+          backgroundColor: '#FFFFFF',
+        }}
+      >
+        <table
+          style={{
+            width: '100%',
+            borderSpacing: 0,
+            borderCollapse: 'collapse',
+            fontFamily: 'monospace',
+            fontSize: `0.9rem`,
+            tableLayout: 'fixed',
+          }}
+        >
+          <tbody>
+            {errorText
+              .split('\n')
+              .map((v, i) => tabelRow(i + 1, highlight(v, i)))}
+          </tbody>
+        </table>
+      </div>
     </Box>
   );
 }

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -1,0 +1,79 @@
+import {
+  AppBar,
+  Container,
+  Toolbar,
+  Typography,
+  Box,
+  Link,
+} from '@mui/material';
+
+export default function Header() {
+  return (
+    <Box>
+      <AppBar
+        position='relative'
+        sx={{
+          bgcolor: 'white',
+          color: 'black',
+          boxShadow: 0,
+          borderBottom: 1,
+          borderColor: 'grey.400',
+        }}
+      >
+        <Container maxWidth='lg'>
+          <Toolbar disableGutters>
+            <Typography
+              variant='h6'
+              noWrap
+              component='a'
+              href='/'
+              sx={{
+                mr: 2,
+                flexGrow: 0,
+                fontFamily: 'monospace',
+                fontWeight: 700,
+                color: 'inherit',
+                textDecoration: 'none',
+              }}
+            >
+              YouQuery
+            </Typography>
+            <Box
+              sx={{
+                flexGrow: 1,
+                display: 'flex',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <Link
+                href='/'
+                component='a'
+                underline='none'
+                sx={{
+                  display: 'block',
+                  p: 1,
+                  color: 'inherit',
+                }}
+              >
+                About
+              </Link>
+              <Link
+                href='https://github.com/jphacks/E_2202'
+                component='a'
+                underline='none'
+                sx={{
+                  display: 'block',
+                  p: 1,
+                  color: 'inherit',
+                }}
+              >
+                GitHub
+              </Link>
+            </Box>
+          </Toolbar>
+        </Container>
+      </AppBar>
+      {/* <Box sx={{ height: '64px' }}></Box> */}
+    </Box>
+  );
+}

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -45,7 +45,7 @@ export default function Header() {
                 justifyContent: 'flex-end',
               }}
             >
-              <Link
+              {/* <Link
                 href='/'
                 component='a'
                 underline='none'
@@ -56,7 +56,7 @@ export default function Header() {
                 }}
               >
                 About
-              </Link>
+              </Link> */}
               <Link
                 href='https://github.com/jphacks/E_2202'
                 component='a'


### PR DESCRIPTION
## やったこと

* エラー文入力欄を一番上にする
* 検索ボタンと検索クエリ欄を解析結果表示欄の下に設ける
* ヘッダーを追加

## できるようになること（ユーザ目線）

* エラー文を一番最初に入力しやすくなった
* 解析ボタンと検索ボタンのどちらを押した方すべきなのか迷わずに済むようになった

## できなくなること（ユーザ目線）

* 無し

## その他

* 無し

close #77 
