### PR TITLE
fix filename url index bug

### DIFF
--- a/server/parser/other.py
+++ b/server/parser/other.py
@@ -23,7 +23,8 @@ def error_parser(error: str) -> list[HighlightTextInfo]:
                 and not_found_pattern.search(line) is None:
             continue
 
-        res = url_pattern.sub("__URL__", line)
-        res = unix_path_pattern.sub("__FILE__", res)
-        result.append(HighlightTextInfo(row_idx, TextIndices(0, len(res)), res, TextType.ERROR_MESSAGE))
+        # URLやファイル名を除去する
+        res = url_pattern.sub("", line)
+        res = unix_path_pattern.sub("", res)
+        result.append(HighlightTextInfo(row_idx, TextIndices(0, len(line)), res, TextType.ERROR_MESSAGE))
     return result


### PR DESCRIPTION
## やったこと

* ファイル名，URLは `__FILE__` や `__URL__` への置換ではなく削除するように変更した
* その他の言語でファイル名やURLを除去した際の index のズレを直した

## できるようになること（ユーザ目線）

* ハイライトがいい感じになったので見やすくなる

## できなくなること（ユーザ目線）

* 無し

## その他

* こんな感じになった

|before|after|
|:---|:---|
|<img width="1184" alt="image" src="https://user-images.githubusercontent.com/33239426/200607293-2a2325ea-dd43-4685-be8d-f34b780c564f.png">|<img width="1184" alt="image" src="https://user-images.githubusercontent.com/33239426/200610068-6bf11007-edbd-4655-9bca-66ddd5eff313.png">|

close #92 
